### PR TITLE
refactor: separate cleanup-betas into dedicated workflow

### DIFF
--- a/.github/workflows/cleanup-betas.yml
+++ b/.github/workflows/cleanup-betas.yml
@@ -1,0 +1,36 @@
+name: Cleanup Beta Releases
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  cleanup:
+    # Only run if PR was closed WITHOUT merge
+    if: github.event.pull_request.merged == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete beta releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr_number="${{ github.event.pull_request.number }}"
+          echo "PR #${pr_number} closed without merge, cleaning up betas..."
+
+          releases=$(gh release list --repo ${{ github.repository }} \
+            --json tagName -q ".[].tagName" | grep "beta.pr${pr_number}" || true)
+
+          if [ -z "$releases" ]; then
+            echo "No beta releases found"
+            exit 0
+          fi
+
+          for tag in $releases; do
+            echo "Deleting: $tag"
+            gh release delete "$tag" --repo ${{ github.repository }} --yes --cleanup-tag || true
+          done
+
+          echo "✅ Cleanup completed"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,32 +123,3 @@ jobs:
           done
 
           echo "✅ Cleanup completed"
-
-  # Cleanup betas anche se PR chiusa senza merge
-  cleanup-on-close:
-    if: github.event.pull_request.merged == false
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Delete beta releases
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          pr_number="${{ github.event.pull_request.number }}"
-          echo "PR #${pr_number} closed without merge, cleaning up betas..."
-
-          releases=$(gh release list --repo ${{ github.repository }} \
-            --json tagName -q ".[].tagName" | grep "beta.pr${pr_number}" || true)
-
-          if [ -z "$releases" ]; then
-            echo "No beta releases found"
-            exit 0
-          fi
-
-          for tag in $releases; do
-            echo "Deleting: $tag"
-            gh release delete "$tag" --repo ${{ github.repository }} --yes --cleanup-tag || true
-          done
-
-          echo "✅ Cleanup completed"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,8 @@ Obsidian plugin that automatically renames pasted images based on the active not
 │   └── RELEASE_WORKFLOW.md # Release process documentation
 ├── .github/workflows/
 │   ├── pr.yml              # PR pipeline: validate → build → beta
-│   └── release.yml         # Release pipeline: build → release → cleanup
+│   ├── release.yml         # Release pipeline: build → release → cleanup
+│   └── cleanup-betas.yml   # Cleanup betas when PR closed without merge
 ├── manifest.json           # Obsidian plugin manifest
 ├── versions.json           # Version → minAppVersion map
 ├── styles.css              # Plugin CSS styles
@@ -80,7 +81,8 @@ PR #42, commit abc1234
 | Workflow | Trigger | Azione |
 |----------|---------|--------|
 | `pr.yml` | PR aperta/aggiornata | validate → build-test → beta-release |
-| `release.yml` | PR chiusa | build → release → cleanup (o solo cleanup se non merged) |
+| `release.yml` | PR merged con label | build → release → cleanup |
+| `cleanup-betas.yml` | PR chiusa senza merge | cleanup beta releases |
 
 ## Local Testing
 ```bash


### PR DESCRIPTION
Extract cleanup-on-close job from release.yml into its own workflow:
- release.yml: only handles merged PRs with release labels
- cleanup-betas.yml: handles PR closed without merge

Cleaner separation of concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)