### PR TITLE
feat: add i18n with EN/IT support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "obsidian-smart-image-renamer",
       "version": "0.7.6",
       "license": "MIT",
+      "dependencies": {
+        "i18next": "^25.7.1"
+      },
       "devDependencies": {
         "@types/node": "^20.19.0",
         "@typescript-eslint/parser": "^8.48.0",
@@ -134,6 +137,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -4150,6 +4162,37 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/i18next": {
+      "version": "25.7.1",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.7.1.tgz",
+      "integrity": "sha512-XbTnkh1yCZWSAZGnA9xcQfHcYNgZs2cNxm+c6v1Ma9UAUGCeJPplRe1ILia6xnDvXBjk0uXU+Z8FYWhA19SKFw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -6615,7 +6658,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "tslib": "^2.8.1",
     "typescript": "^5.8.3",
     "vitest": "^3.2.4"
+  },
+  "dependencies": {
+    "i18next": "^25.7.1"
   }
 }

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,44 @@
+import i18next from 'i18next';
+import { moment } from 'obsidian';
+import en from './locales/en.json';
+import it from './locales/it.json';
+import type { TranslationKeys } from './types';
+
+const SUPPORTED_LOCALES = ['en', 'it'] as const;
+type SupportedLocale = typeof SUPPORTED_LOCALES[number];
+
+const resources = {
+	en: { translation: en },
+	it: { translation: it },
+};
+
+function getSupportedLocale(locale: string): SupportedLocale {
+	const lang = locale.split('-')[0]; // "en-US" → "en"
+	return SUPPORTED_LOCALES.includes(lang as SupportedLocale)
+		? (lang as SupportedLocale)
+		: 'en';
+}
+
+// Initialize i18next
+void i18next.init({
+	lng: getSupportedLocale(moment.locale()),
+	fallbackLng: 'en',
+	resources,
+	interpolation: {
+		escapeValue: false, // Not needed for Obsidian
+	},
+});
+
+/**
+ * Translate a key with optional interpolation values.
+ * Automatically syncs with Obsidian's current language.
+ */
+export function t(key: TranslationKeys, options?: Record<string, unknown>): string {
+	const currentLocale = getSupportedLocale(moment.locale());
+	if (i18next.language !== currentLocale) {
+		void i18next.changeLanguage(currentLocale);
+	}
+	return i18next.t(key, options);
+}
+
+export { i18next };

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,0 +1,139 @@
+{
+	"commands": {
+		"renameInNote": "Rename images in current note",
+		"renameInVault": "Rename all images in vault",
+		"findOrphaned": "Find orphaned images"
+	},
+	"settings": {
+		"suffixMode": {
+			"name": "Suffix mode",
+			"desc": "How to generate the suffix for image filenames",
+			"sequential": "Sequential (1, 2, 3...)",
+			"timestamp": "Timestamp"
+		},
+		"timestampFormat": {
+			"name": "Timestamp format",
+			"desc": "Choose a preset or custom format"
+		},
+		"customFormat": {
+			"name": "Custom format",
+			"desc": "Supports year, month, day, hour, minute, second tokens"
+		},
+		"autoRename": {
+			"name": "Auto-rename images from any source",
+			"desc": "Automatically rename images with generic names (Pasted image, Screenshot, etc.) when created from any source: drag & drop, Excalidraw, or other plugins."
+		},
+		"suffixesToRemove": {
+			"name": "Suffixes to remove from note names",
+			"desc": "Comma-separated list of suffixes to strip from note names. Example: .excalidraw,.canvas (removes \".excalidraw\" from \"Drawing.excalidraw.md\")",
+			"placeholder": "Suffixes to strip"
+		},
+		"aggressiveSanitization": {
+			"name": "Aggressive filename sanitization",
+			"desc": "When enabled, filenames are converted to URL-friendly format: lowercase, spaces → underscores, accents removed (é → e). When disabled, only invalid filesystem characters are removed. This applies to both pasted images and manual renames."
+		},
+		"preview": "Preview",
+		"previewExample": "Example: {{example}}"
+	},
+	"notices": {
+		"noImagesInNote": "No images found in current note",
+		"noImagesInVault": "No images found in vault",
+		"allImagesCorrect": "All images are already correctly named!",
+		"noOrphanedImages": "No orphaned images found. Your vault is clean!",
+		"invalidFilename": "Invalid filename",
+		"renamedTo": "Renamed to {{name}}",
+		"failedToRename": "Failed to rename: {{error}}",
+		"imageNotFound": "Image not found: {{name}}",
+		"noActiveFile": "No active file found",
+		"imageSavedAs": "Image saved as {{name}}",
+		"failedToSave": "Failed to save image: {{error}}",
+		"autoRenamedTo": "Auto-renamed to {{name}}",
+		"autoRenameExistsError": "Could not auto-rename \"{{name}}\" - a file with that name already exists. Right-click on the image to rename it manually.",
+		"failedToAutoRename": "Failed to auto-rename: {{error}}",
+		"noImagesSelected": "No images selected",
+		"successfullyRenamed_one": "Successfully renamed {{count}} image",
+		"successfullyRenamed_other": "Successfully renamed {{count}} images",
+		"renamedWithErrors": "Renamed {{success}}, failed {{failed}}. Check console for details.",
+		"deleted_one": "Deleted {{count}} image (moved to trash)",
+		"deleted_other": "Deleted {{count}} images (moved to trash)",
+		"deletedWithErrors": "Deleted {{success}}, failed {{failed}}. Check console.",
+		"moved_one": "Moved {{count}} image to {{folder}}/",
+		"moved_other": "Moved {{count}} images to {{folder}}/",
+		"movedWithErrors": "Moved {{success}}, failed {{failed}}. Check console."
+	},
+	"menu": {
+		"renameImage": "Rename image"
+	},
+	"bulkRename": {
+		"title": "Bulk rename images",
+		"scope": {
+			"name": "Scope",
+			"desc": "Where to search for images",
+			"note": "Current note",
+			"vault": "Entire vault"
+		},
+		"filter": {
+			"name": "Filter",
+			"desc": "Which images to include",
+			"generic": "Only generic names (pasted, screenshot...)",
+			"all": "All images"
+		},
+		"mode": {
+			"name": "Rename mode",
+			"desc": "How to generate new names",
+			"replace": "Use note name (note 1, note 2...)",
+			"prepend": "Prepend note name (note - original)",
+			"pattern": "Custom pattern"
+		},
+		"pattern": {
+			"name": "Pattern",
+			"desc": "Use {note}, {original}, {n} as placeholders"
+		},
+		"selectAll": "Select all",
+		"selectNone": "Select none",
+		"renameSelected": "Rename selected",
+		"cancel": "Cancel",
+		"scanning": "Scanning...",
+		"noImagesFound": "No images found matching the filter.",
+		"foundImages_one": "Found {{count}} image to rename:",
+		"foundImages_other": "Found {{count}} images to rename:",
+		"orphanImages_one": "{{count}} orphan image (not linked):",
+		"orphanImages_other": "{{count}} orphan images (not linked):",
+		"manageOrphans": "Manage orphans →",
+		"renaming_one": "Renaming {{count}} image...",
+		"renaming_other": "Renaming {{count}} images...",
+		"tagGeneric": "auto",
+		"tagOrphan": "orphan",
+		"inNote": "in"
+	},
+	"orphanedImages": {
+		"title": "Orphaned images",
+		"stats_one": "Found {{count}} orphaned image ({{size}} total)",
+		"stats_other": "Found {{count}} orphaned images ({{size}} total)",
+		"hint": "These images are not linked from any note, canvas, or Excalidraw file.",
+		"empty": "No orphaned images found. Your vault is clean!",
+		"selectedCount": "{{count}} selected",
+		"moveFolder": {
+			"name": "Move folder",
+			"desc": "Folder to move orphaned images to"
+		},
+		"deleteSelected": "Delete selected",
+		"moveSelected": "Move selected",
+		"deleting_one": "Deleting {{count}} image...",
+		"deleting_other": "Deleting {{count}} images...",
+		"moving_one": "Moving {{count}} image to {{folder}}/...",
+		"moving_other": "Moving {{count}} images to {{folder}}/..."
+	},
+	"confirmDelete": {
+		"title": "Confirm deletion",
+		"message_one": "Are you sure you want to delete {{count}} image?",
+		"message_other": "Are you sure you want to delete {{count}} images?",
+		"hint": "Files will be moved to your system trash and can be recovered.",
+		"delete": "Delete"
+	},
+	"renameModal": {
+		"title": "Rename image",
+		"current": "Current: {{name}}",
+		"rename": "Rename"
+	}
+}

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1,0 +1,139 @@
+{
+	"commands": {
+		"renameInNote": "Rinomina immagini nella nota corrente",
+		"renameInVault": "Rinomina tutte le immagini nel vault",
+		"findOrphaned": "Trova immagini orfane"
+	},
+	"settings": {
+		"suffixMode": {
+			"name": "Modalità suffisso",
+			"desc": "Come generare il suffisso per i nomi dei file immagine",
+			"sequential": "Sequenziale (1, 2, 3...)",
+			"timestamp": "Timestamp"
+		},
+		"timestampFormat": {
+			"name": "Formato timestamp",
+			"desc": "Scegli un preset o un formato personalizzato"
+		},
+		"customFormat": {
+			"name": "Formato personalizzato",
+			"desc": "Supporta token per anno, mese, giorno, ora, minuto, secondo"
+		},
+		"autoRename": {
+			"name": "Rinomina automaticamente da qualsiasi fonte",
+			"desc": "Rinomina automaticamente le immagini con nomi generici (Pasted image, Screenshot, ecc.) quando create da qualsiasi fonte: drag & drop, Excalidraw o altri plugin."
+		},
+		"suffixesToRemove": {
+			"name": "Suffissi da rimuovere dai nomi delle note",
+			"desc": "Lista di suffissi separati da virgola da rimuovere dai nomi delle note. Esempio: .excalidraw,.canvas (rimuove \".excalidraw\" da \"Drawing.excalidraw.md\")",
+			"placeholder": "Suffissi da rimuovere"
+		},
+		"aggressiveSanitization": {
+			"name": "Sanitizzazione aggressiva dei nomi file",
+			"desc": "Se abilitato, i nomi file vengono convertiti in formato URL-friendly: minuscolo, spazi → underscore, accenti rimossi (é → e). Se disabilitato, vengono rimossi solo i caratteri non validi per il filesystem. Si applica sia alle immagini incollate che alle rinominazioni manuali."
+		},
+		"preview": "Anteprima",
+		"previewExample": "Esempio: {{example}}"
+	},
+	"notices": {
+		"noImagesInNote": "Nessuna immagine trovata nella nota corrente",
+		"noImagesInVault": "Nessuna immagine trovata nel vault",
+		"allImagesCorrect": "Tutte le immagini hanno già nomi corretti!",
+		"noOrphanedImages": "Nessuna immagine orfana trovata. Il tuo vault è pulito!",
+		"invalidFilename": "Nome file non valido",
+		"renamedTo": "Rinominato in {{name}}",
+		"failedToRename": "Impossibile rinominare: {{error}}",
+		"imageNotFound": "Immagine non trovata: {{name}}",
+		"noActiveFile": "Nessun file attivo trovato",
+		"imageSavedAs": "Immagine salvata come {{name}}",
+		"failedToSave": "Impossibile salvare l'immagine: {{error}}",
+		"autoRenamedTo": "Rinominata automaticamente in {{name}}",
+		"autoRenameExistsError": "Impossibile rinominare automaticamente \"{{name}}\" - esiste già un file con quel nome. Fai clic destro sull'immagine per rinominarla manualmente.",
+		"failedToAutoRename": "Impossibile rinominare automaticamente: {{error}}",
+		"noImagesSelected": "Nessuna immagine selezionata",
+		"successfullyRenamed_one": "Rinominata {{count}} immagine",
+		"successfullyRenamed_other": "Rinominate {{count}} immagini",
+		"renamedWithErrors": "Rinominate {{success}}, fallite {{failed}}. Controlla la console per i dettagli.",
+		"deleted_one": "Eliminata {{count}} immagine (spostata nel cestino)",
+		"deleted_other": "Eliminate {{count}} immagini (spostate nel cestino)",
+		"deletedWithErrors": "Eliminate {{success}}, fallite {{failed}}. Controlla la console.",
+		"moved_one": "Spostata {{count}} immagine in {{folder}}/",
+		"moved_other": "Spostate {{count}} immagini in {{folder}}/",
+		"movedWithErrors": "Spostate {{success}}, fallite {{failed}}. Controlla la console."
+	},
+	"menu": {
+		"renameImage": "Rinomina immagine"
+	},
+	"bulkRename": {
+		"title": "Rinomina immagini in blocco",
+		"scope": {
+			"name": "Ambito",
+			"desc": "Dove cercare le immagini",
+			"note": "Nota corrente",
+			"vault": "Intero vault"
+		},
+		"filter": {
+			"name": "Filtro",
+			"desc": "Quali immagini includere",
+			"generic": "Solo nomi generici (pasted, screenshot...)",
+			"all": "Tutte le immagini"
+		},
+		"mode": {
+			"name": "Modalità rinomina",
+			"desc": "Come generare i nuovi nomi",
+			"replace": "Usa nome nota (nota 1, nota 2...)",
+			"prepend": "Anteponi nome nota (nota - originale)",
+			"pattern": "Pattern personalizzato"
+		},
+		"pattern": {
+			"name": "Pattern",
+			"desc": "Usa {note}, {original}, {n} come placeholder"
+		},
+		"selectAll": "Seleziona tutto",
+		"selectNone": "Deseleziona tutto",
+		"renameSelected": "Rinomina selezionate",
+		"cancel": "Annulla",
+		"scanning": "Scansione...",
+		"noImagesFound": "Nessuna immagine trovata con il filtro selezionato.",
+		"foundImages_one": "Trovata {{count}} immagine da rinominare:",
+		"foundImages_other": "Trovate {{count}} immagini da rinominare:",
+		"orphanImages_one": "{{count}} immagine orfana (non collegata):",
+		"orphanImages_other": "{{count}} immagini orfane (non collegate):",
+		"manageOrphans": "Gestisci orfane →",
+		"renaming_one": "Rinomina {{count}} immagine...",
+		"renaming_other": "Rinomina {{count}} immagini...",
+		"tagGeneric": "auto",
+		"tagOrphan": "orfana",
+		"inNote": "in"
+	},
+	"orphanedImages": {
+		"title": "Immagini orfane",
+		"stats_one": "Trovata {{count}} immagine orfana ({{size}} totali)",
+		"stats_other": "Trovate {{count}} immagini orfane ({{size}} totali)",
+		"hint": "Queste immagini non sono collegate da nessuna nota, canvas o file Excalidraw.",
+		"empty": "Nessuna immagine orfana trovata. Il tuo vault è pulito!",
+		"selectedCount": "{{count}} selezionate",
+		"moveFolder": {
+			"name": "Cartella destinazione",
+			"desc": "Cartella in cui spostare le immagini orfane"
+		},
+		"deleteSelected": "Elimina selezionate",
+		"moveSelected": "Sposta selezionate",
+		"deleting_one": "Eliminazione {{count}} immagine...",
+		"deleting_other": "Eliminazione {{count}} immagini...",
+		"moving_one": "Spostamento {{count}} immagine in {{folder}}/...",
+		"moving_other": "Spostamento {{count}} immagini in {{folder}}/..."
+	},
+	"confirmDelete": {
+		"title": "Conferma eliminazione",
+		"message_one": "Sei sicuro di voler eliminare {{count}} immagine?",
+		"message_other": "Sei sicuro di voler eliminare {{count}} immagini?",
+		"hint": "I file verranno spostati nel cestino di sistema e potranno essere recuperati.",
+		"delete": "Elimina"
+	},
+	"renameModal": {
+		"title": "Rinomina immagine",
+		"current": "Attuale: {{name}}",
+		"rename": "Rinomina"
+	}
+}

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1,0 +1,21 @@
+import en from './locales/en.json';
+
+// Remove plural suffixes (_one, _other) from key strings
+type RemovePluralSuffix<S extends string> = S extends `${infer Base}_one`
+	? Base
+	: S extends `${infer Base}_other`
+		? Base
+		: S;
+
+// Generate nested key paths from translation object
+type NestedKeyOf<T, K extends string = ''> = T extends object
+	? {
+			[P in keyof T & string]: T[P] extends object
+				? NestedKeyOf<T[P], K extends '' ? P : `${K}.${P}`>
+				: K extends ''
+					? RemovePluralSuffix<P>
+					: `${K}.${RemovePluralSuffix<P>}`;
+		}[keyof T & string]
+	: never;
+
+export type TranslationKeys = NestedKeyOf<typeof en>;

--- a/src/ui/bulk-rename-modal.ts
+++ b/src/ui/bulk-rename-modal.ts
@@ -8,6 +8,7 @@ import {
 	BulkRenameScope,
 } from '../types/bulk-rename';
 import { OrphanedImagesModal } from './orphaned-images-modal';
+import { t } from '../i18n';
 
 export class BulkRenameModal extends Modal {
 	private service: BulkRenameService;
@@ -48,7 +49,7 @@ export class BulkRenameModal extends Modal {
 
 	private renderHeader(): void {
 		const { contentEl } = this;
-		new Setting(contentEl).setName('Bulk rename images').setHeading();
+		new Setting(contentEl).setName(t('bulkRename.title')).setHeading();
 	}
 
 	private renderControls(): void {
@@ -57,12 +58,12 @@ export class BulkRenameModal extends Modal {
 
 		// Scope selector
 		new Setting(controlsDiv)
-			.setName('Scope')
-			.setDesc('Where to search for images')
+			.setName(t('bulkRename.scope.name'))
+			.setDesc(t('bulkRename.scope.desc'))
 			.addDropdown((dropdown) => {
 				dropdown
-					.addOption('note', 'Current note')
-					.addOption('vault', 'Entire vault')
+					.addOption('note', t('bulkRename.scope.note'))
+					.addOption('vault', t('bulkRename.scope.vault'))
 					.setValue(this.renameScope)
 					.setDisabled(!this.activeNote)
 					.onChange((value: BulkRenameScope) => {
@@ -73,12 +74,12 @@ export class BulkRenameModal extends Modal {
 
 		// Filter selector
 		new Setting(controlsDiv)
-			.setName('Filter')
-			.setDesc('Which images to include')
+			.setName(t('bulkRename.filter.name'))
+			.setDesc(t('bulkRename.filter.desc'))
 			.addDropdown((dropdown) => {
 				dropdown
-					.addOption('generic', 'Only generic names (pasted, screenshot...)')
-					.addOption('all', 'All images')
+					.addOption('generic', t('bulkRename.filter.generic'))
+					.addOption('all', t('bulkRename.filter.all'))
 					.setValue(this.filter)
 					.onChange((value: ImageFilter) => {
 						this.filter = value;
@@ -88,13 +89,13 @@ export class BulkRenameModal extends Modal {
 
 		// Mode selector
 		new Setting(controlsDiv)
-			.setName('Rename mode')
-			.setDesc('How to generate new names')
+			.setName(t('bulkRename.mode.name'))
+			.setDesc(t('bulkRename.mode.desc'))
 			.addDropdown((dropdown) => {
 				dropdown
-					.addOption('replace', 'Use note name (note 1, note 2...)')
-					.addOption('prepend', 'Prepend note name (note - original)')
-					.addOption('pattern', 'Custom pattern')
+					.addOption('replace', t('bulkRename.mode.replace'))
+					.addOption('prepend', t('bulkRename.mode.prepend'))
+					.addOption('pattern', t('bulkRename.mode.pattern'))
 					.setValue(this.mode)
 					.onChange((value: BulkRenameMode) => {
 						this.mode = value;
@@ -105,8 +106,8 @@ export class BulkRenameModal extends Modal {
 
 		// Pattern input (shown only for pattern mode)
 		this.patternSetting = new Setting(controlsDiv)
-			.setName('Pattern')
-			.setDesc('Use {note}, {original}, {n} as placeholders')
+			.setName(t('bulkRename.pattern.name'))
+			.setDesc(t('bulkRename.pattern.desc'))
 			.addText((text) => {
 				text
 					.setValue(this.pattern)
@@ -136,13 +137,13 @@ export class BulkRenameModal extends Modal {
 		const selectDiv = footerDiv.createDiv({ cls: 'bulk-rename-select-actions' });
 
 		const selectAllBtn = selectDiv.createEl('button', {
-			text: 'Select all',
+			text: t('bulkRename.selectAll'),
 			cls: 'mod-muted',
 		});
 		selectAllBtn.addEventListener('click', () => this.selectAll(true));
 
 		const selectNoneBtn = selectDiv.createEl('button', {
-			text: 'Select none',
+			text: t('bulkRename.selectNone'),
 			cls: 'mod-muted',
 		});
 		selectNoneBtn.addEventListener('click', () => this.selectAll(false));
@@ -151,18 +152,18 @@ export class BulkRenameModal extends Modal {
 		new Setting(footerDiv)
 			.addButton((btn) =>
 				btn
-					.setButtonText('Rename selected')
+					.setButtonText(t('bulkRename.renameSelected'))
 					.setCta()
 					.onClick(() => this.executeRename())
 			)
 			.addButton((btn) =>
-				btn.setButtonText('Cancel').onClick(() => this.close())
+				btn.setButtonText(t('bulkRename.cancel')).onClick(() => this.close())
 			);
 	}
 
 	private async scanAndPreview(): Promise<void> {
 		this.listContainer.empty();
-		this.listContainer.createEl('p', { text: 'Scanning...', cls: 'bulk-rename-scanning' });
+		this.listContainer.createEl('p', { text: t('bulkRename.scanning'), cls: 'bulk-rename-scanning' });
 
 		// Scan images
 		if (this.renameScope === 'note' && this.activeNote) {
@@ -193,7 +194,7 @@ export class BulkRenameModal extends Modal {
 
 		if (this.previewItems.length === 0 && orphanImages.length === 0) {
 			this.listContainer.createEl('p', {
-				text: 'No images found matching the filter.',
+				text: t('bulkRename.noImagesFound'),
 				cls: 'bulk-rename-empty',
 			});
 			return;
@@ -203,7 +204,7 @@ export class BulkRenameModal extends Modal {
 		if (this.previewItems.length > 0) {
 			const count = this.previewItems.length;
 			this.listContainer.createEl('p', {
-				text: `Found ${count} image${count !== 1 ? 's' : ''} to rename:`,
+				text: t('bulkRename.foundImages', { count }),
 				cls: 'bulk-rename-count',
 			});
 
@@ -218,12 +219,12 @@ export class BulkRenameModal extends Modal {
 			const orphanHeader = this.listContainer.createDiv({ cls: 'bulk-rename-orphan-header' });
 
 			orphanHeader.createEl('p', {
-				text: `${orphanImages.length} orphan image${orphanImages.length !== 1 ? 's' : ''} (not linked):`,
+				text: t('bulkRename.orphanImages', { count: orphanImages.length }),
 				cls: 'bulk-rename-count bulk-rename-orphan-title',
 			});
 
 			const manageBtn = orphanHeader.createEl('button', {
-				text: 'Manage orphans →',
+				text: t('bulkRename.manageOrphans'),
 				cls: 'mod-muted bulk-rename-manage-orphans-btn',
 			});
 			manageBtn.addEventListener('click', () => this.openOrphanedImagesModal());
@@ -261,7 +262,7 @@ export class BulkRenameModal extends Modal {
 		currentName.createSpan({ text: `.${item.file.extension}`, cls: 'bulk-rename-ext' });
 
 		if (item.isGeneric) {
-			currentRow.createSpan({ text: 'auto', cls: 'bulk-rename-tag bulk-rename-tag-generic' });
+			currentRow.createSpan({ text: t('bulkRename.tagGeneric'), cls: 'bulk-rename-tag bulk-rename-tag-generic' });
 		}
 
 		// Row 2: New proposed name
@@ -274,7 +275,7 @@ export class BulkRenameModal extends Modal {
 		// Row 3: Source note (if available)
 		if (item.sourceNote) {
 			const sourceRow = contentEl.createDiv({ cls: 'bulk-rename-row bulk-rename-source-row' });
-			sourceRow.createSpan({ text: 'in ' });
+			sourceRow.createSpan({ text: t('bulkRename.inNote') + ' ' });
 			sourceRow.createSpan({ text: item.sourceNote.basename, cls: 'bulk-rename-source-note' });
 		}
 	}
@@ -296,7 +297,7 @@ export class BulkRenameModal extends Modal {
 		const name = nameRow.createSpan({ cls: 'bulk-rename-current-name' });
 		name.createSpan({ text: image.file.basename });
 		name.createSpan({ text: `.${image.file.extension}`, cls: 'bulk-rename-ext' });
-		nameRow.createSpan({ text: 'orphan', cls: 'bulk-rename-tag bulk-rename-tag-orphan' });
+		nameRow.createSpan({ text: t('bulkRename.tagOrphan'), cls: 'bulk-rename-tag bulk-rename-tag-orphan' });
 
 		// Path
 		const pathRow = contentEl.createDiv({ cls: 'bulk-rename-row bulk-rename-source-row' });
@@ -320,24 +321,22 @@ export class BulkRenameModal extends Modal {
 		const selectedCount = this.previewItems.filter((i) => i.selected).length;
 
 		if (selectedCount === 0) {
-			new Notice('No images selected');
+			new Notice(t('notices.noImagesSelected'));
 			return;
 		}
 
 		this.listContainer.empty();
 		this.listContainer.createEl('p', {
-			text: `Renaming ${selectedCount} image${selectedCount !== 1 ? 's' : ''}...`,
+			text: t('bulkRename.renaming', { count: selectedCount }),
 			cls: 'bulk-rename-progress',
 		});
 
 		const result = await this.service.executeBulkRename(this.previewItems);
 
 		if (result.failed === 0) {
-			new Notice(`Successfully renamed ${result.success} image${result.success !== 1 ? 's' : ''}`);
+			new Notice(t('notices.successfullyRenamed', { count: result.success }));
 		} else {
-			new Notice(
-				`Renamed ${result.success}, failed ${result.failed}. Check console for details.`
-			);
+			new Notice(t('notices.renamedWithErrors', { success: result.success, failed: result.failed }));
 			console.error('Bulk rename errors:', result.errors);
 		}
 

--- a/src/ui/rename-modal.ts
+++ b/src/ui/rename-modal.ts
@@ -1,4 +1,5 @@
 import { App, Modal, Setting, TFile } from 'obsidian';
+import { t } from '../i18n';
 
 export class RenameImageModal extends Modal {
 	private file: TFile;
@@ -15,9 +16,9 @@ export class RenameImageModal extends Modal {
 		const { contentEl } = this;
 		contentEl.addClass('rename-image-modal');
 
-		new Setting(contentEl).setName('Rename image').setHeading();
+		new Setting(contentEl).setName(t('renameModal.title')).setHeading();
 		contentEl.createEl('p', {
-			text: `Current: ${this.file.basename}`,
+			text: t('renameModal.current', { name: this.file.basename }),
 			cls: 'rename-image-current'
 		});
 
@@ -35,12 +36,12 @@ export class RenameImageModal extends Modal {
 
 		new Setting(contentEl)
 			.addButton((btn) =>
-				btn.setButtonText('Rename')
+				btn.setButtonText(t('renameModal.rename'))
 					.setCta()
 					.onClick(() => this.submit())
 			)
 			.addButton((btn) =>
-				btn.setButtonText('Cancel')
+				btn.setButtonText(t('bulkRename.cancel'))
 					.onClick(() => this.close())
 			);
 

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -1,6 +1,7 @@
 import { App, Plugin, PluginSettingTab, Setting } from 'obsidian';
 import { SmartImageRenamerSettings } from '../types/settings';
 import { TIMESTAMP_PRESETS, formatTimestamp } from '../utils';
+import { t } from '../i18n';
 
 export interface SettingsProvider {
 	settings: SmartImageRenamerSettings;
@@ -21,11 +22,11 @@ export class SmartImageRenamerSettingTab extends PluginSettingTab {
 
 		// Suffix Mode
 		new Setting(containerEl)
-			.setName('Suffix mode')
-			.setDesc('How to generate the suffix for image filenames')
+			.setName(t('settings.suffixMode.name'))
+			.setDesc(t('settings.suffixMode.desc'))
 			.addDropdown(dropdown => dropdown
-				.addOption('sequential', 'Sequential (1, 2, 3...)')
-				.addOption('timestamp', 'Timestamp')
+				.addOption('sequential', t('settings.suffixMode.sequential'))
+				.addOption('timestamp', t('settings.suffixMode.timestamp'))
 				.setValue(this.provider.settings.suffixMode)
 				.onChange(async (value: 'sequential' | 'timestamp') => {
 					this.provider.settings.suffixMode = value;
@@ -40,8 +41,8 @@ export class SmartImageRenamerSettingTab extends PluginSettingTab {
 			);
 
 			new Setting(containerEl)
-				.setName('Timestamp format')
-				.setDesc('Choose a preset or custom format')
+				.setName(t('settings.timestampFormat.name'))
+				.setDesc(t('settings.timestampFormat.desc'))
 				.addDropdown(dropdown => {
 					TIMESTAMP_PRESETS.forEach(preset => {
 						dropdown.addOption(preset.value, preset.label);
@@ -61,8 +62,8 @@ export class SmartImageRenamerSettingTab extends PluginSettingTab {
 			// Show custom format field if custom is selected
 			if (isCustom) {
 				new Setting(containerEl)
-					.setName('Custom format')
-					.setDesc('Supports year, month, day, hour, minute, second tokens')
+					.setName(t('settings.customFormat.name'))
+					.setDesc(t('settings.customFormat.desc'))
 					.addText(text => {
 						text.setValue(this.provider.settings.timestampFormat)
 							.setPlaceholder('20240101-120000')
@@ -76,11 +77,8 @@ export class SmartImageRenamerSettingTab extends PluginSettingTab {
 
 		// Auto-rename on create
 		new Setting(containerEl)
-			.setName('Auto-rename images from any source')
-			.setDesc(
-				'Automatically rename images with generic names (Pasted image, Screenshot, etc.) ' +
-				'when created from any source: drag & drop, Excalidraw, or other plugins.'
-			)
+			.setName(t('settings.autoRename.name'))
+			.setDesc(t('settings.autoRename.desc'))
 			.addToggle(toggle => toggle
 				.setValue(this.provider.settings.autoRenameOnCreate)
 				.onChange(async (value) => {
@@ -90,14 +88,11 @@ export class SmartImageRenamerSettingTab extends PluginSettingTab {
 
 		// Suffixes to remove
 		new Setting(containerEl)
-			.setName('Suffixes to remove from note names')
-			.setDesc(
-				'Comma-separated list of suffixes to strip from note names. ' +
-				'Example: .excalidraw,.canvas (removes ".excalidraw" from "Drawing.excalidraw.md")'
-			)
+			.setName(t('settings.suffixesToRemove.name'))
+			.setDesc(t('settings.suffixesToRemove.desc'))
 			.addText(text => text
 				.setValue(this.provider.settings.suffixesToRemove.join(', '))
-				.setPlaceholder('Suffixes to strip')
+				.setPlaceholder(t('settings.suffixesToRemove.placeholder'))
 				.onChange(async (value) => {
 					this.provider.settings.suffixesToRemove = value
 						.split(',')
@@ -108,13 +103,8 @@ export class SmartImageRenamerSettingTab extends PluginSettingTab {
 
 		// Aggressive Sanitization Toggle
 		new Setting(containerEl)
-			.setName('Aggressive filename sanitization')
-			.setDesc(
-				'When enabled, filenames are converted to URL-friendly format: ' +
-				'lowercase, spaces → underscores, accents removed (é → e). ' +
-				'When disabled, only invalid filesystem characters are removed. ' +
-				'This applies to both pasted images and manual renames.'
-			)
+			.setName(t('settings.aggressiveSanitization.name'))
+			.setDesc(t('settings.aggressiveSanitization.desc'))
 			.addToggle(toggle => toggle
 				.setValue(this.provider.settings.aggressiveSanitization)
 				.onChange(async (value) => {
@@ -124,7 +114,7 @@ export class SmartImageRenamerSettingTab extends PluginSettingTab {
 				}));
 
 		// Preview
-		new Setting(containerEl).setName("Preview").setHeading();
+		new Setting(containerEl).setName(t('settings.preview')).setHeading();
 		const previewEl = containerEl.createEl('p', { cls: 'setting-item-description' });
 		this.updatePreview(previewEl);
 	}
@@ -141,6 +131,6 @@ export class SmartImageRenamerSettingTab extends PluginSettingTab {
 			suffix = '1';
 		}
 
-		el.setText(`Example: ${exampleNote} ${suffix}.png`);
+		el.setText(t('settings.previewExample', { example: `${exampleNote} ${suffix}.png` }));
 	}
 }

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -449,3 +449,8 @@ export function createMockImageElement(src: string): HTMLImageElement {
 	img.setAttribute('src', src);
 	return img;
 }
+
+// Mock moment with locale() method for i18n
+export const moment = {
+	locale: vi.fn().mockReturnValue('en'),
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,9 +13,10 @@
 		"strictNullChecks": true,
 		"allowSyntheticDefaultImports": true,
 		"esModuleInterop": true,
+		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"lib": ["DOM", "ES5", "ES6", "ES7"]
 	},
-	"include": ["main.ts", "src/**/*.ts"],
+	"include": ["main.ts", "src/**/*.ts", "src/**/*.json"],
 	"exclude": ["tests/**/*", "vitest.config.ts", "node_modules"]
 }


### PR DESCRIPTION
- Add i18next with type-safe translation keys
- Auto-detect language from Obsidian locale
- Live language switching (no plugin reload)
- Pluralization support (_one/_other)
- Migrate all UI strings to translation files