### PR TITLE
refactor(i18n): simplify locale detection

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,9 @@
       "Bash(npm root:*)",
       "Bash(npm ls:*)",
       "Bash(npx eslint .)",
-      "Bash(cat:*)"
+      "Bash(cat:*)",
+      "WebSearch",
+      "Bash(gh run list:*)"
     ],
     "deny": [],
     "ask": []

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,5 +1,4 @@
 import i18next from 'i18next';
-import { moment } from 'obsidian';
 import en from './locales/en.json';
 import it from './locales/it.json';
 import type { TranslationKeys } from './types';
@@ -12,32 +11,33 @@ const resources = {
 	it: { translation: it },
 };
 
-function getSupportedLocale(locale: string): SupportedLocale {
-	const lang = locale.split('-')[0]; // "en-US" → "en"
-	return SUPPORTED_LOCALES.includes(lang as SupportedLocale)
-		? (lang as SupportedLocale)
-		: 'en';
+function getObsidianLocale(): SupportedLocale {
+	try {
+		const stored = window.localStorage?.getItem('language');
+		if (!stored) return 'en';
+		const lang = stored.split('-')[0]; // "en-US" → "en"
+		return SUPPORTED_LOCALES.includes(lang as SupportedLocale)
+			? (lang as SupportedLocale)
+			: 'en';
+	} catch {
+		return 'en';
+	}
 }
 
-// Initialize i18next
+// Initialize i18next once at load time
 void i18next.init({
-	lng: getSupportedLocale(moment.locale()),
+	lng: getObsidianLocale(),
 	fallbackLng: 'en',
 	resources,
 	interpolation: {
-		escapeValue: false, // Not needed for Obsidian
+		escapeValue: false,
 	},
 });
 
 /**
  * Translate a key with optional interpolation values.
- * Automatically syncs with Obsidian's current language.
  */
 export function t(key: TranslationKeys, options?: Record<string, unknown>): string {
-	const currentLocale = getSupportedLocale(moment.locale());
-	if (i18next.language !== currentLocale) {
-		void i18next.changeLanguage(currentLocale);
-	}
 	return i18next.t(key, options);
 }
 

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -450,7 +450,3 @@ export function createMockImageElement(src: string): HTMLImageElement {
 	return img;
 }
 
-// Mock moment with locale() method for i18n
-export const moment = {
-	locale: vi.fn().mockReturnValue('en'),
-};


### PR DESCRIPTION
- Use localStorage like other Obsidian plugins
- Remove per-call locale check (app reloads on lang change)
- Add fallback for test environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)