### PR TITLE
fix: remove unnecessary async from scanAndPreview method

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,17 @@
       "Bash(npx eslint .)",
       "Bash(cat:*)",
       "WebSearch",
-      "Bash(gh run list:*)"
+      "Bash(gh run list:*)",
+      "mcp__github__pull_request_read",
+      "mcp__github__get_tag",
+      "mcp__github__list_releases",
+      "mcp__github__get_file_contents",
+      "Bash(gh pr checks:*)",
+      "mcp__github__list_commits",
+      "WebFetch(domain:forum.obsidian.md)",
+      "mcp__github__get_commit",
+      "Bash(npm run build:*)",
+      "Bash(npm run lint:*)"
     ],
     "deny": [],
     "ask": []

--- a/src/ui/bulk-rename-modal.ts
+++ b/src/ui/bulk-rename-modal.ts
@@ -161,7 +161,7 @@ export class BulkRenameModal extends Modal {
 			);
 	}
 
-	private async scanAndPreview(): Promise<void> {
+	private scanAndPreview(): void {
 		this.listContainer.empty();
 		this.listContainer.createEl('p', { text: t('bulkRename.scanning'), cls: 'bulk-rename-scanning' });
 


### PR DESCRIPTION
The method doesn't use any await expressions, so async is not needed. Fixes eslint '@typescript-eslint/require-await' error.
