### PR TITLE
fix: handle Folder already exists race condition

### DIFF
--- a/src/services/bulk-rename-service.ts
+++ b/src/services/bulk-rename-service.ts
@@ -293,7 +293,14 @@ export class BulkRenameService {
 	private async ensureFolderExists(folderPath: string): Promise<void> {
 		const folder = this.app.vault.getAbstractFileByPath(folderPath);
 		if (!folder) {
-			await this.app.vault.createFolder(folderPath);
+			try {
+				await this.app.vault.createFolder(folderPath);
+			} catch (error) {
+				// Ignore "Folder already exists" - race condition with Obsidian or sync services
+				if (!(error instanceof Error && error.message.includes('already exists'))) {
+					throw error;
+				}
+			}
 		}
 	}
 

--- a/src/services/file-service.ts
+++ b/src/services/file-service.ts
@@ -43,7 +43,14 @@ export class FileService {
 			currentPath = currentPath ? `${currentPath}/${part}` : part;
 			const existing = this.app.vault.getAbstractFileByPath(currentPath);
 			if (!existing) {
-				await this.app.vault.createFolder(currentPath);
+				try {
+					await this.app.vault.createFolder(currentPath);
+				} catch (error) {
+					// Ignore "Folder already exists" - race condition with Obsidian or sync services
+					if (!(error instanceof Error && error.message.includes('already exists'))) {
+						throw error;
+					}
+				}
 			}
 		}
 	}

--- a/tests/services/file-service.test.ts
+++ b/tests/services/file-service.test.ts
@@ -77,6 +77,19 @@ describe('FileService', () => {
 			expect(app.vault.createFolder).toHaveBeenCalledWith('path/to');
 			expect(app.vault.createFolder).toHaveBeenCalledWith('path/to/folder');
 		});
+
+		it('should ignore "Folder already exists" error (race condition)', async () => {
+			vi.spyOn(app.vault, 'createFolder').mockRejectedValueOnce(new Error('Folder already exists.'));
+
+			// Should not throw
+			await expect(fileService.ensureFolderExists('new-folder')).resolves.toBeUndefined();
+		});
+
+		it('should throw other errors', async () => {
+			vi.spyOn(app.vault, 'createFolder').mockRejectedValueOnce(new Error('Permission denied'));
+
+			await expect(fileService.ensureFolderExists('new-folder')).rejects.toThrow('Permission denied');
+		});
 	});
 
 	describe('getAvailablePath', () => {


### PR DESCRIPTION
## Summary
Fix console error "Folder already exists" reported in #34.

## Root cause
TOCTOU race condition in `ensureFolderExists`:
- `getAbstractFileByPath` returns null (folder not in cache)
- Between check and `createFolder`, another process creates folder
- `createFolder` throws "Folder already exists"

## Causes
- Race with Obsidian's internal paste/drop handlers
- Race with sync services (iCloud, Dropbox, etc.)
- Obsidian cache lag (folder exists on disk but not indexed)

## Fix
Catch "Folder already exists" error and ignore it (desired state achieved).
Other errors still thrown.

## Test plan
- [x] Unit test for race condition scenario
- [x] Unit test ensuring other errors still thrown

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)